### PR TITLE
[launch] Use IAM instance profile

### DIFF
--- a/launch/.gitignore
+++ b/launch/.gitignore
@@ -1,2 +1,3 @@
 *tfstate*
 terraform.tfvars
+secrets.erb

--- a/launch/README.md
+++ b/launch/README.md
@@ -18,14 +18,11 @@ under `/tmp/puppet/`.
 
 * __Install [terraform](https://www.terraform.io/downloads.html)__
 
-* __Specifying AWS Credentials__: Read
-[AWS provider](https://www.terraform.io/docs/providers/aws/) to use
-environment variables to pass in credentials.
-
 * __Add Instance Details__: Copy
 [terraform.tfvars.sample](terraform.tfvars.sample) to `terraform.tfvars` and
-add image ID, security group, ssh key pair name and path to ssh private key.
-This is required to ssh into the instance and run the provisioners.
+add iam_instance_profile (with proper permissions), image ID, security group,
+ssh key pair name and path to ssh private key. This is required to ssh into
+the instance and run the provisioners.
 
 * __Install Puppet Modules__: Terraform uploads puppet modules from local to
 remote machine. This requires installation of puppet modules before running

--- a/launch/main.tf
+++ b/launch/main.tf
@@ -8,6 +8,8 @@ resource "aws_instance" "spaceship" {
   associate_public_ip_address = "${var.enable_public_ip}"
   key_name = "${var.key_pair}"
   vpc_security_group_ids = ["${var.sg_id}"]
+  iam_instance_profile = "${var.iam_instance_profile}"
+  tags = "${var.tags}"
 
   provisioner "remote-exec" {
     inline = [

--- a/launch/manifests/hieradata/common.yaml.sample
+++ b/launch/manifests/hieradata/common.yaml.sample
@@ -9,6 +9,4 @@ secrets_path: '/home/ubuntu/.secrets'
 
 repo: 'git@github.com:username/repo-name.git'
 repopath: '/home/ubuntu/repo-name'
-aws_access_key_id: ''
-aws_secret_access_key: ''
 aws_region: 'us-east-1'

--- a/launch/manifests/site.pp
+++ b/launch/manifests/site.pp
@@ -20,11 +20,6 @@ vcsrepo { hiera('repopath'):
   user     => hiera('system_user'),
 }
 
-# Variables to be used in secrets template
-$aws_access_key_id = hiera('aws_access_key_id')
-$aws_secret_access_key = hiera('aws_secret_access_key')
-$aws_region = hiera('aws_region')
-
 # Create secrets file
 file { hiera('secrets_path'):
   ensure  => file,

--- a/launch/manifests/templates/secrets.erb
+++ b/launch/manifests/templates/secrets.erb
@@ -1,3 +1,0 @@
-export AWS_ACCESS_KEY_ID=<%= @aws_access_key_id %>
-export AWS_SECRET_ACCESS_KEY=<%= @aws_secret_access_key %>
-export AWS_DEFAULT_REGION=<%= @aws_region %>

--- a/launch/manifests/templates/secrets.erb.sample
+++ b/launch/manifests/templates/secrets.erb.sample
@@ -1,0 +1,1 @@
+export TF_VAR_varname=SOME_VAR_VALUE

--- a/launch/terraform.tfvars.sample
+++ b/launch/terraform.tfvars.sample
@@ -2,7 +2,9 @@
 /*region = ""*/
 /*instance_type = ""*/
 /*enable_public_ip =*/
+/*tags = {}*/
 
+iam_instance_profile = ""
 image_id = ""
 key_pair = ""
 sg_id = "instanec-security-group-id"

--- a/launch/variables.tf
+++ b/launch/variables.tf
@@ -6,9 +6,17 @@ variable "image_id" {}
 variable "instance_type" {
   default = "t2.large"
 }
+variable "iam_instance_profile" {
+  default = ""
+}
 variable "enable_public_ip" {
   default = true
 }
 variable "key_pair" {}
 variable "sg_id" {}
 variable "private_key_path" {}
+variable "tags" {
+  default = {
+      Name = "my-spaceship"
+  }
+}


### PR DESCRIPTION
Removes all the code related to aws credentials and adds
iam_instance_profile. Using instance profile is much better security
practice.