### PR TITLE
[launch] Add subnet for VPC instances and perm

### DIFF
--- a/launch/README.md
+++ b/launch/README.md
@@ -41,10 +41,20 @@ be cloned and adding the private key in `manifests/files/private_key` file.
 Depending upon the use-case, the deployment key would have read & write
 permissions.
 
+* __Secrets__: Copy
+[secrets.erb.sample](manifests/templates/secrets.erb.sample) to `secrets.erb`
+and put the secrets that should be part of environment variables.
+
+
 __NOTE__: __[ssh_config](manifests/files/ssh_config)__ file is added as
 `.ssh/config` of the machine with `StrictHostKeyChecking` disabled for
 `github.com`. This is done to skip host key check while cloning a repo for
 for first time using ssh keys, else repo cloning fails.
+
+
+## IAM Policy Permissions
+
+Inshort, `AmazonEC2FullAccess` and `IAMFullAccess`.
 
 
 ## Running

--- a/launch/main.tf
+++ b/launch/main.tf
@@ -8,6 +8,7 @@ resource "aws_instance" "spaceship" {
   associate_public_ip_address = "${var.enable_public_ip}"
   key_name = "${var.key_pair}"
   vpc_security_group_ids = ["${var.sg_id}"]
+  subnet_id = "${var.subnet_id}"
   iam_instance_profile = "${var.iam_instance_profile}"
   tags = "${var.tags}"
 

--- a/launch/terraform.tfvars.sample
+++ b/launch/terraform.tfvars.sample
@@ -1,6 +1,7 @@
 /* Optional */
 /*region = ""*/
 /*instance_type = ""*/
+/*subnet_id = ""*/
 /*enable_public_ip =*/
 /*tags = {}*/
 

--- a/launch/variables.tf
+++ b/launch/variables.tf
@@ -6,6 +6,7 @@ variable "image_id" {}
 variable "instance_type" {
   default = "t2.large"
 }
+variable "subnet_id" {}
 variable "iam_instance_profile" {
   default = ""
 }


### PR DESCRIPTION
Subnet is required to derive VPC ID of the instance when in VPC. Without
specific EC2 and IAM accesses, provisioning fails.